### PR TITLE
Revert "add tgz support to tar creation keyword"

### DIFF
--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -87,7 +87,7 @@ class ArchiveKeywords:
 
         self.collections.list_should_contain_value(files, filename)
 
-    def create_tar_from_files_in_directory(self, directory, filename, sub_directories=True, tgz=False):
+    def create_tar_from_files_in_directory(self, directory, filename, sub_directories=True):
         """ Take all files in a directory and create a tar package from them
 
         `directory` Path to the directory that holds our files
@@ -95,14 +95,9 @@ class ArchiveKeywords:
         `filename` Path to our destination TAR package.
 
         `sub_directories` Shall files in sub-directories be included - True by default.        
-
-        `tgz` Creates a .tgz / .tar.gz archive (compressed tar package) instead of a regular tar - False by default.
         """
-        if tgz:
-            tar = tarfile.open(filename, "w")
-        else:
-            tar = tarfile.open(filename, "w:gz")
-        
+        tar = tarfile.open(filename, "w")
+
         files = return_files_lists(directory, sub_directories)
         for filepath, name in files:
             tar.add(filepath, arcname=name)

--- a/atests/testcase.robot
+++ b/atests/testcase.robot
@@ -60,15 +60,6 @@ Create TAR Package from files in directory
     Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
     Remove File    ${tarfilename}
 
-Create TGZ Package from files in directory
-    ${tarfilename}=    set variable    newTgzFile.tgz
-    Remove File    ${tarfilename}
-    Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}    tgz=True
-    Archive Should Contain File    ${tarfilename}    file1.txt
-    Archive Should Contain File    ${tarfilename}    file2.txt
-    Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
-    Remove File    ${tarfilename}
-
 Create TAR Package from files in directory, without subdirectories
     ${tarfilename}=    set variable    newTarFile.tar
     Remove File    ${tarfilename}


### PR DESCRIPTION
Reverts MarketSquare/robotframework-archivelibrary#40

Unittest broken that show a not backward compatible change.
I think this if is switched:

```python
        if tgz:
            tar = tarfile.open(filename, "w")
        else:
            tar = tarfile.open(filename, "w:gz")
```